### PR TITLE
Remove unnecessary permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,15 +12,10 @@
     "default_title": "copy",
     "default_popup": "views/popup.html"
   },
-  "content_scripts": [
-    {
-      "js": ["scripts/content.js"],
-      "matches": ["https://github.com/*/*/issues/*"]
-    }
-  ],
   "content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'",
   "permissions": [
     "clipboardWrite",
+    "activeTab",
     "declarativeContent"
   ],
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,6 @@
   ],
   "content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'",
   "permissions": [
-    "tabs",
     "clipboardWrite",
     "declarativeContent"
   ],

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,42 +1,46 @@
-chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
-  if (!!request.format) {
-    copy(request.format);
+(function() {
+  if (window.isAlreadyPrepared) return;
+  window.isAlreadyPrepared = true;
+  chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    if (!!request.format) {
+      copy(request.format);
+    }
+  });
+
+  function copy(format) {
+    return execCopy(getFormattedIssueLink(format));
   }
-});
 
-function copy(format) {
-  return execCopy(getFormattedIssueLink(format));
-}
+  function execCopy(text) {
+    var textArea = document.createElement('textarea');
+    textArea.style.cssText = 'position:absolute;left:-100%;';
 
-function execCopy(text) {
-  var textArea = document.createElement('textarea');
-  textArea.style.cssText = 'position:absolute;left:-100%;';
+    document.body.appendChild(textArea);
 
-  document.body.appendChild(textArea);
+    textArea.value = text;
+    textArea.select();
+    document.execCommand('copy');
 
-  textArea.value = text;
-  textArea.select();
-  document.execCommand('copy');
-
-  document.body.removeChild(textArea);
-}
-
-function getFormattedIssueLink(format) {
-  var h1 = 'h1.gh-header-title';
-  var title = document.querySelectorAll(`${h1} .js-issue-title`)[0].innerText.trim();
-  var num = document.querySelectorAll(`${h1} .gh-header-number`)[0].innerText;
-  var url = window.location.href;
-
-  switch (format) {
-    case 'markdown':
-      return `[${num}｜${title}](${url})`;
-      break;
-    case 'html':
-      return `<a href="${url}">${num}｜${title}</a>`;
-      break;
-    case 'plain':
-      return `${num}｜${title}\n${url}`;
-      break;
+    document.body.removeChild(textArea);
   }
-  return '';
-}
+
+  function getFormattedIssueLink(format) {
+    var h1 = 'h1.gh-header-title';
+    var title = document.querySelectorAll(`${h1} .js-issue-title`)[0].innerText.trim();
+    var num = document.querySelectorAll(`${h1} .gh-header-number`)[0].innerText;
+    var url = window.location.href;
+
+    switch (format) {
+      case 'markdown':
+        return `[${num}｜${title}](${url})`;
+        break;
+      case 'html':
+        return `<a href="${url}">${num}｜${title}</a>`;
+        break;
+      case 'plain':
+        return `${num}｜${title}\n${url}`;
+        break;
+    }
+    return '';
+  }
+})();

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -1,12 +1,17 @@
 var buttons = document.getElementById('buttons');
 buttons.addEventListener('click', function (e) {
   ga('send', 'event', 'copy', 'click', e.target.id);
-  sendClick(e.target.id);
-  window.close();
+  sendClick(e.target.id, function () {
+    window.close();
+  });
 });
 
-function sendClick(formatType) {
+function sendClick(formatType, callback) {
   chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-    chrome.tabs.sendMessage(tabs[0].id, {format: formatType}, function(response) {});
+    chrome.tabs.executeScript(tabs[0].id, {
+      "file": "scripts/content.js"
+    }, function () {
+      chrome.tabs.sendMessage(tabs[0].id, {format: formatType}, callback);
+    });
   });
 }


### PR DESCRIPTION
## Removed permissions
* `tabs`
  * [chrome.tabs - Google Chrome](https://developer.chrome.com/extensions/tabs "https://developer.chrome.com/extensions/tabs")  
  > The majority of the chrome.tabs API can be used without declaring any permission. However, the "tabs" permission is required in order to populate the url, title, and favIconUrl properties of Tab. 
  * This extension does not use the url, title, and favIconUrl properties.
* github.com
  * Change to using `activeTab` permission

----
(Japanese version)
## 削除した権限
* `tabs`
  * url, title, favIconUrlプロパティを使わないなら `tabs` 権限は無くてOKです
* github.com
  * `activeTab` 権限を使えば（必要なときにだけ）現在のタブでcodeを実行できます
  * コピーするときに初めて `content.js` を実行するようにしました

// タブが閉じるのが早すぎてコピーされないことがあったのでclose処理を少し遅らせました