### PR TITLE
Migrate from Manifest V2 to V3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,22 +1,21 @@
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
   "default_locale": "ja",
   "background": {
-    "scripts": ["scripts/background.js"],
-    "persistent": false
+    "service_worker": "scripts/background.js"
   },
-  "page_action": {
+  "action": {
     "default_icon": "images/icon32.png",
     "default_title": "copy",
     "default_popup": "views/popup.html"
   },
-  "content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'",
   "permissions": [
     "clipboardWrite",
     "activeTab",
-    "declarativeContent"
+    "declarativeContent",
+    "scripting"
   ],
   "icons": {
     "16": "images/icon16.png",
@@ -24,5 +23,5 @@
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   },
-  "manifest_version": 2
+  "manifest_version": 3
 }

--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -1,8 +1,0 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://ssl.google-analytics.com/analytics.js','ga');
-
-ga('create', 'UA-43703750-2', 'auto');
-ga('set', 'checkProtocolTask', null);
-ga('send', 'pageview', {page: '/popup.html', title: 'popup'});

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -12,7 +12,7 @@ chrome.runtime.onInstalled.addListener(function() {
             css: ['.gh-header-title']
           })
         ],
-        actions: [ new chrome.declarativeContent.ShowPageAction() ]
+        actions: [ new chrome.declarativeContent.ShowAction() ]
       }
     ]);
   });

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -8,20 +8,7 @@
   });
 
   function copy(format) {
-    return execCopy(getFormattedIssueLink(format));
-  }
-
-  function execCopy(text) {
-    var textArea = document.createElement('textarea');
-    textArea.style.cssText = 'position:absolute;left:-100%;';
-
-    document.body.appendChild(textArea);
-
-    textArea.value = text;
-    textArea.select();
-    document.execCommand('copy');
-
-    document.body.removeChild(textArea);
+    navigator.clipboard.writeText(getFormattedIssueLink(format));
   }
 
   function getFormattedIssueLink(format) {
@@ -49,4 +36,3 @@
     return /^https:\/\/github.com\/(.+)\/(.+)\/pull\/(\d+)/.test(url)
   }
 })();
-

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -1,6 +1,5 @@
 var buttons = document.getElementById('buttons');
 buttons.addEventListener('click', function (e) {
-  ga('send', 'event', 'copy', 'click', e.target.id);
   sendClick(e.target.id, function () {
     window.close();
   });
@@ -8,8 +7,9 @@ buttons.addEventListener('click', function (e) {
 
 function sendClick(formatType, callback) {
   chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-    chrome.tabs.executeScript(tabs[0].id, {
-      "file": "scripts/content.js"
+    chrome.scripting.executeScript({
+      target: { tabId: tabs[0].id },
+      files: ["scripts/content.js"]
     }, function () {
       chrome.tabs.sendMessage(tabs[0].id, {format: formatType}, callback);
     });

--- a/views/popup.html
+++ b/views/popup.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<script type="text/javascript" src="../scripts/analytics.js"></script>
-		<link href="https://fonts.googleapis.com/css?family=Lato:900" rel="stylesheet">
 		<link href="../styles/popup.css" rel="stylesheet">
 	</head>
   <body>


### PR DESCRIPTION
## Summary
- Migrate Chrome extension from Manifest V2 to V3
- Replace background scripts with service worker
- Replace `page_action` with `action` and `ShowPageAction` with `ShowAction`
- Replace `chrome.tabs.executeScript` with `chrome.scripting.executeScript` (add `scripting` permission)
- Replace `document.execCommand('copy')` with `navigator.clipboard.writeText()`
- Remove Google Analytics (`analytics.js`) and external font dependency
- Bump version to 0.3.0

## Test plan
- [x] Load unpacked extension in Chrome and verify it loads without errors
- [x] Verify the action icon appears on GitHub issue/PR pages
- [x] Test all copy format buttons (plain, markdown, etc.) and confirm clipboard content
- [x] Verify extension works on both issue and pull request pages
- [x] Check no console errors related to Manifest V3 deprecations

🤖 Generated with [Claude Code](https://claude.com/claude-code)