### PR TITLE
Fix broken selectors for GitHub's updated HTML structure

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,4 +1,5 @@
 chrome.runtime.onInstalled.addListener(function() {
+  chrome.action.disable();
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
     chrome.declarativeContent.onPageChanged.addRules([
       {
@@ -7,9 +8,9 @@ chrome.runtime.onInstalled.addListener(function() {
             pageUrl: {
               hostEquals: 'github.com',
               schemes: ['https'],
-              urlMatches: '/(.+)/(.+)/issues|pull/(\\d+)'
+              urlMatches: '/(.+)/(.+)/(issues|pull)/(\\d+)'
             },
-            css: ['.gh-header-title']
+            css: ['.markdown-title']
           })
         ],
         actions: [ new chrome.declarativeContent.ShowAction() ]

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -2,19 +2,18 @@
   if (window.isAlreadyPrepared) return;
   window.isAlreadyPrepared = true;
   chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
-    if (!!request.format) {
-      copy(request.format);
+    if (request.format) {
+      sendResponse({ text: getFormattedIssueLink(request.format) });
+    } else {
+      sendResponse({});
     }
   });
 
-  function copy(format) {
-    navigator.clipboard.writeText(getFormattedIssueLink(format));
-  }
-
   function getFormattedIssueLink(format) {
-    var h1 = 'h1.gh-header-title';
-    var title = document.querySelectorAll(`${h1} .js-issue-title`)[0].innerText.trim();
-    var num = document.querySelectorAll(`${h1} .f1-light`)[0].innerText;
+    var titleEl = document.querySelector('[data-component="TitleArea"] .markdown-title');
+    var title = titleEl ? titleEl.innerText.trim() : '';
+    var match = window.location.pathname.match(/\/(issues|pull)\/(\d+)/);
+    var num = match ? '#' + match[2] : '';
     var url = window.location.href;
     var type = isPullRequestUrl(url) ? ' (Pull request)' : '';
 

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -11,7 +11,11 @@ function sendClick(formatType, callback) {
       target: { tabId: tabs[0].id },
       files: ["scripts/content.js"]
     }, function () {
-      chrome.tabs.sendMessage(tabs[0].id, {format: formatType}, callback);
+      chrome.tabs.sendMessage(tabs[0].id, {format: formatType}, function(response) {
+        if (response && response.text) {
+          navigator.clipboard.writeText(response.text).then(callback);
+        }
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #12

## Summary
- Update CSS selectors for issue/PR title (`.markdown-title`) and extract number from URL
- Move clipboard write from content script to popup to fix `NotAllowedError`
- Ensure `sendResponse` is always called to prevent message port errors
- Fix URL pattern regex and `chrome.action.disable()` for proper page matching

## Test plan
- [x] Open a GitHub issue page → extension icon appears, copy works
- [x] Open a GitHub PR page → extension icon appears, copy works
- [x] Open other GitHub pages → extension icon does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)