### PR TITLE
Remove HTML format option

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -21,9 +21,6 @@
       case 'markdown':
         return `[${num}｜${title}${type}](${url})`;
         break;
-      case 'html':
-        return `<a href="${url}">${num}｜${title}${type}</a>`;
-        break;
       case 'plain':
         return `${num}｜${title}${type}\n${url}`;
         break;

--- a/views/popup.html
+++ b/views/popup.html
@@ -5,8 +5,7 @@
 	</head>
   <body>
 		<div id="buttons">
-	    <button id="markdown">Markdown</button>
-			<button id="html">HTML</button>
+			<button id="markdown">Markdown</button>
 			<button id="plain">Plain text</button>
 		</div>
     <script type="text/javascript" src="../scripts/popup.js"></script>


### PR DESCRIPTION
## Summary
- Remove unused HTML copy format option
- Delete HTML button from popup and corresponding case in content.js
- Keep only Markdown and Plain text options

## Test plan
- [x] Reload extension and verify only Markdown and Plain text buttons appear in popup
- [x] Verify each button works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)