### PR TITLE
Redesign popup UI with GitHub Primer ActionMenu style

### DIFF
--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -1,6 +1,8 @@
 var buttons = document.getElementById('buttons');
 buttons.addEventListener('click', function (e) {
-  sendClick(e.target.id, function () {
+  var item = e.target.closest('.ActionList-item');
+  if (!item) return;
+  sendClick(item.id, function () {
     window.close();
   });
 });

--- a/styles/popup.css
+++ b/styles/popup.css
@@ -1,25 +1,68 @@
 body {
-  font-family: 'Lato', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  color: #1f2328;
+}
+
+.ActionMenu {
+  width: 220px;
+  padding: 4px 0;
+}
+
+.ActionMenu-header {
+  font-size: 12px;
+  font-weight: 600;
+  color: #656d76;
+  padding: 6px 16px;
+}
+
+.ActionMenu-divider {
+  height: 1px;
+  background: #d1d9e0;
+  margin: 4px 0;
+}
+
+.ActionList {
+  list-style: none;
   margin: 0;
   padding: 0;
 }
 
-#buttons {
-  width: 90px;
-  padding: 2px 0px;
-}
-
-#buttons button {
-  width: 100%;
-  font-weight: bold;
-  color: #333333;
-  outline: none;
+.ActionList-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  margin: 0 4px;
+  border-radius: 6px;
   border: none;
   background: none;
-  text-align: left;
-  padding: 4px 10px;
+  font-size: 14px;
+  color: #1f2328;
+  cursor: pointer;
 }
 
-#buttons button:active {
-  background: #f7f7f7;
+.ActionList-item:hover {
+  background: #eef1f4;
+}
+
+.ActionList-item:active {
+  background: #d1d9e0;
+}
+
+.ActionList-item:focus-visible {
+  outline: 2px solid #0969da;
+  outline-offset: -2px;
+}
+
+.ActionList-item > * {
+  pointer-events: none;
+}
+
+.ActionList-item svg {
+  width: 16px;
+  height: 16px;
+  fill: #656d76;
+  flex-shrink: 0;
 }

--- a/views/popup.html
+++ b/views/popup.html
@@ -3,11 +3,21 @@
 	<head>
 		<link href="../styles/popup.css" rel="stylesheet">
 	</head>
-  <body>
-		<div id="buttons">
-			<button id="markdown">Markdown</button>
-			<button id="plain">Plain text</button>
+	<body>
+		<div class="ActionMenu">
+			<div class="ActionMenu-header">Copy link as</div>
+			<div class="ActionMenu-divider"></div>
+			<ul class="ActionList" id="buttons" role="menu">
+				<li class="ActionList-item" id="markdown" role="menuitem" tabindex="0">
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M14.85 3c.63 0 1.15.52 1.14 1.15v7.7c0 .63-.51 1.15-1.15 1.15H1.15C.52 13 0 12.48 0 11.84V4.15C0 3.52.52 3 1.15 3ZM9 11V5H7L5.5 7 4 5H2v6h2V8l1.5 1.92L7 8v3Zm2.99.5L14.5 8H13V5h-2v3H9.5Z"/></svg>
+					<span>Markdown</span>
+				</li>
+				<li class="ActionList-item" id="plain" role="menuitem" tabindex="0">
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M6.71 10H2.332l-.874 2.498a.75.75 0 0 1-1.415-.496l3.39-9.688a1.217 1.217 0 0 1 2.302.018l3.227 9.681a.75.75 0 0 1-1.423.474Zm-.536-1.5L4.527 3.65 2.858 8.5ZM14.75 10.5a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5Z"/></svg>
+					<span>Plain text</span>
+				</li>
+			</ul>
 		</div>
-    <script type="text/javascript" src="../scripts/popup.js"></script>
-  </body>
+		<script type="text/javascript" src="../scripts/popup.js"></script>
+	</body>
 </html>


### PR DESCRIPTION
## Summary
- Replace plain button layout with GitHub Primer ActionMenu component pattern
- Add Octicons SVG icons (markdown mark for Markdown, typography "Aa" for Plain text)
- Improve popup styling with hover/active/focus states and proper spacing
- Fix click handler to use `closest()` for reliable event delegation on `<li>` items

## Test plan
- [x] Reload extension at `chrome://extensions`
- [x] Open popup and verify ActionMenu-style UI is displayed
- [x] Verify Markdown icon (M↗) and Plain text icon (Aa) render correctly
- [x] Click each menu item and confirm copy functionality works

🤖 Generated with [Claude Code](https://claude.com/claude-code)